### PR TITLE
feat(claude): add claude code commands and makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOTFILES_DIR := $(shell pwd)
 
-all: brew wezterm neovim starship zsh gitconfig mise karabiner vscode postgres macos bin claude
+all: brew wezterm neovim starship zsh gitconfig mise karabiner vscode postgres macos bin claude claude_commands
 
 brew:
 	@echo "Setting up Homebrew..."
@@ -72,6 +72,16 @@ claude:
 	mkdir -p $(HOME)/.claude
 	ln -sf $(DOTFILES_DIR)/claude/CLAUDE.md $(HOME)/.claude/CLAUDE.md
 
+claude_commands:
+	@echo "Setting up Claude commands..."
+	mkdir -p $(HOME)/.claude/commands
+	@for file in $(DOTFILES_DIR)/claude/commands/*.md; do \
+		if [ -f "$$file" ]; then \
+			echo "Linking $$(basename $$file)..."; \
+			ln -sf "$$file" "$(HOME)/.claude/commands/$$(basename $$file)"; \
+		fi; \
+	done
+
 help:
 	@echo "make targets available:"
 	@echo "  all"
@@ -89,5 +99,6 @@ help:
 	@echo "  macos"
 	@echo "  bin"
 	@echo "  claude"
+	@echo "  claude_commands"
 
-.PHONY: all brew brew_dump wezterm neovim starship raycast zsh gitconfig mise vscode karabiner postgres macos bin claude help
+.PHONY: all brew brew_dump wezterm neovim starship raycast zsh gitconfig mise vscode karabiner postgres macos bin claude claude_commands help

--- a/claude/commands/create-commit.md
+++ b/claude/commands/create-commit.md
@@ -1,0 +1,16 @@
+# commitメッセージを作成
+
+## 前提
+
+- TODO.md をcommitに含める場合は確認をする
+
+## 実行手順
+1. `git status`でファイルを確認
+2. [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)に従ってコミットを実行
+
+## 形式の指定
+- type(scope): subject の形式に従う
+- タイトルは50文字以内、本文は72文字程度で改行
+- 動詞は原形を使用（add, fix, updateなど）
+- scope は原則記述するが、適切なものがない場合は省略可
+- コミットメッセージは小文字で始める

--- a/claude/commands/git-create-branch-commit-pr.md
+++ b/claude/commands/git-create-branch-commit-pr.md
@@ -1,0 +1,6 @@
+# branch & commit & pr を作成
+
+## 実行手順
+1. Read @~/.claude/commands/create-branch.md を実行
+2. Read @~/.claude/commands/create-commit.md を実行
+3. Read @~/.claude/commands/create-pr.md を実行

--- a/claude/commands/git-create-branch.md
+++ b/claude/commands/git-create-branch.md
@@ -1,0 +1,8 @@
+# git-create-branch
+
+## branchを作成
+
+- ブランチ名は [Conventional Branch](https://conventional-branch.github.io/) に従う
+- feature/[FeatureName]-[実装した機能名]
+
+例: feature/admin-user-role-edit-invite-form

--- a/claude/commands/git-create-pr.md
+++ b/claude/commands/git-create-pr.md
@@ -1,0 +1,6 @@
+# PRを作成
+
+- Read @.github/PULL_REQUEST_TEMPLATE.md に従うこと
+- Draftで作成すること
+- push時は`git push -u origin <branch_name>` のように `--set-upstream` を指定すること
+- コマンドの例: `gh pr create --draft --title "title" --body "body"`

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -136,7 +136,7 @@ function _fzf-repo-edit() {
             fi
         else
             # 通常の動作: Vimで開く
-            vim "$selected" < /dev/tty
+            vim "$selected" < /dev/tty > /dev/tty
         fi
     fi
     zle reset-prompt
@@ -155,6 +155,7 @@ alias tapply="terraform apply"
 alias tplan="terraform plan"
 alias vim=nvim
 alias zs="source ~/.zshrc"
+alias claude="~/.claude/local/claude"
 
 # ================================
 #            exports


### PR DESCRIPTION
## Summary
- Add Claude Code commands for git workflow automation
- Add Makefile target to link command files to ~/.claude/commands/
- Add zsh alias for easy Claude access

## Test plan
- [ ] Run `make claude_commands` to verify command files are linked correctly
- [ ] Test git workflow commands work as expected
- [ ] Verify zsh alias works

🤖 Generated with [Claude Code](https://claude.ai/code)